### PR TITLE
Remove non-determinism from `find_minimum_NFVS`

### DIFF
--- a/nfvsmotifs/interaction_graph_utils.py
+++ b/nfvsmotifs/interaction_graph_utils.py
@@ -13,6 +13,7 @@ from networkx.algorithms import bipartite # type: ignore
 from pyeda.boolalg.expr import expr # type: ignore
 from pyeda.boolalg.bdd import expr2bdd, bddvar # type: ignore
 
+from nfvsmotifs.pyeda_utils import aeon_to_pyeda
 from nfvsmotifs.SignedGraph import SignedGraph
 
 """
@@ -203,7 +204,7 @@ def find_minimum_NFVS(network: BooleanNetwork) -> list[str]:
         if function.strip() == var_name:
             source_nodes.append(var_name)
 
-        fx = expr(function.replace("!", "~"))
+        fx = aeon_to_pyeda(function)
 
         INx[var_name] = fx.support # list of nodes appearing in Boolean function fx
 
@@ -249,7 +250,7 @@ def find_minimum_NFVS(network: BooleanNetwork) -> list[str]:
 
 
     """First, find feedback vertex set"""
-    U = FVS.FVS(u_ig)
+    U = FVS.FVS(u_ig, randomseed=0)
 
     U = list(set(U) - set(source_nodes))
 

--- a/tests/interaction_graph_utils_test.py
+++ b/tests/interaction_graph_utils_test.py
@@ -356,6 +356,10 @@ def test_fvs_accuracy_CASCADE3():
     nfvs_mtsNFVS = find_minimum_NFVS(bn_real)
 
     assert len(nfvs_mtsNFVS) <= 19 # the result of mtsNFVS is 19
+
+    for _i in range(10):
+        nfvs = find_minimum_NFVS(bn_real)
+        assert nfvs == nfvs_mtsNFVS
     
 
 def test_fvs_accuracy_SIPC():
@@ -486,4 +490,7 @@ def test_fvs_accuracy_SIPC():
 
     assert len(nfvs_mtsNFVS) <= 13 # the result of mtsNFVS is 13
     
+    for _i in range(10):
+        nfvs = find_minimum_NFVS(bn_real)
+        assert nfvs == nfvs_mtsNFVS
 


### PR DESCRIPTION
This PR should resolve #36. 

 - It fixes a random seed in the `FVS` constructor.
 - It tests that the results are deterministic by re-running them 10 times (this fails without the fixed seed).
 - It uses proper translation between AEON and PyEDA expressions.