### PR TITLE
Fix `int` vs `str` problems when representing spaces

### DIFF
--- a/nfvsmotifs/space_utils.py
+++ b/nfvsmotifs/space_utils.py
@@ -173,7 +173,7 @@ def percolate_pyeda_expression(expression: Expression, space: dict[str, int]) ->
     return expression.simplify()
 
 
-def expression_to_space_list(expression: Expression) -> list[dict[str, str]]:
+def expression_to_space_list(expression: Expression) -> list[dict[str, int]]:
     """
         Convert a PyEDA expression to a list of subspaces whose union represents
         an equivalent set of network states.
@@ -200,9 +200,9 @@ def expression_to_space_list(expression: Expression) -> list[dict[str, str]]:
         for literal in literals:
             var = str(literal.inputs[0])
             if isinstance(literal, Variable):
-                sub_space[var] = "1"
+                sub_space[var] = 1
             elif isinstance(literal, Complement):
-                sub_space[var] = "0"
+                sub_space[var] = 0
             else:
                 raise Exception(f"Unreachable: Invalid literal type `{type(literal)}`.")
         

--- a/nfvsmotifs/trappist_core.py
+++ b/nfvsmotifs/trappist_core.py
@@ -267,7 +267,7 @@ def _create_clingo_fixed_point_constraints(
     # Ensure that solutions must have desired variables fixed based on `ensure_subspace`.
     for fixed_var in ensure_subspace:
         positive = False
-        if ensure_subspace[fixed_var] == "1":
+        if ensure_subspace[fixed_var] == 1:
             positive = True
         ctl.add("base", [], f"{variable_to_place(fixed_var, positive)}.")
 
@@ -278,7 +278,7 @@ def _create_clingo_fixed_point_constraints(
                 Note that this is opposite to the case of trap spaces.
                 m(x) = 0 ~ place b0_x and m(x) = 1 ~ place b1_x
             """
-            fixed_list = [ variable_to_place(var, (to_avoid[var] == "1")) for var in to_avoid ]
+            fixed_list = [ variable_to_place(var, (to_avoid[var] == 1)) for var in to_avoid ]
             fixed_vars = ", ".join(fixed_list)
             ctl.add("base", [], f":- {fixed_vars}.")
         else:
@@ -309,7 +309,7 @@ def compute_fixed_point_reduced_STG_async(
     reduced_petri_net = petri_net.copy()
     for node in retained_set.keys():
         b_i = retained_set[node]
-        source_place = variable_to_place(node, positive = (b_i == "1"))
+        source_place = variable_to_place(node, positive = (b_i == 1))
         
         preds = list(reduced_petri_net.predecessors(source_place))
         succs = list(reduced_petri_net.successors(source_place))

--- a/tests/space_utils_test.py
+++ b/tests/space_utils_test.py
@@ -80,8 +80,8 @@ def test_expression_to_spaces():
 
     spaces = expression_to_space_list(e)
 
-    assert {'f': '1'} in spaces
-    assert {'a': '1', 'c': '1'} in spaces
-    assert {'d': '0', 'a': '1'} in spaces
-    assert {'d': '0', 'c': '1'} in spaces
-    assert {'a': '1', 'c': '0'} not in spaces
+    assert {'f': 1} in spaces
+    assert {'a': 1, 'c': 1} in spaces
+    assert {'d': 0, 'a': 1} in spaces
+    assert {'d': 0, 'c': 1} in spaces
+    assert {'a': 1, 'c': 0} not in spaces

--- a/tests/trappist_core_test.py
+++ b/tests/trappist_core_test.py
@@ -60,19 +60,19 @@ def test_network_fixed_point_reduced_STG():
 
     petri_net = network_to_petrinet(bn)
     nodes = []
-    avoid_subspace_1 = {"x1" : "1", "x2" : "1"}
+    avoid_subspace_1 = {"x1" : 1, "x2" : 1}
     avoid_subspace_2 = {}
-    avoid_subspace_3 = {"x2" : "1"}
+    avoid_subspace_3 = {"x2" : 1}
 
     ensure_subspace_1 = {}
-    ensure_subspace_2 = {"x1" : "0", "x2" : "0"}
+    ensure_subspace_2 = {"x1" : 0, "x2" : 0}
 
     for var in bn.variables():
         name = bn.get_variable_name(var)
         nodes.append(name)
 
 
-    retained_set = {"x1" : "0", "x2" : "0"}
+    retained_set = {"x1" : 0, "x2" : 0}
     candidate_set = compute_fixed_point_reduced_STG(petri_net, nodes, retained_set)
     assert len(candidate_set) == 2 # candidate_set = {00, 11}
 
@@ -85,7 +85,7 @@ def test_network_fixed_point_reduced_STG():
     candidate_set = compute_fixed_point_reduced_STG(petri_net, nodes, retained_set, ensure_subspace=ensure_subspace_2)
     assert len(candidate_set) == 1 # candidate_set = {00}
 
-    retained_set = {"x1" : "1", "x2" : "1"}
+    retained_set = {"x1" : 1, "x2" : 1}
     candidate_set = compute_fixed_point_reduced_STG(petri_net, nodes, retained_set)
     assert len(candidate_set) == 3 # candidate_set = {01, 10, 11}
 


### PR DESCRIPTION
This PR is related to #26. It introduces bug fixes based on #35 related to space/state representation.