### PR TITLE
Block (scc) expansion

### DIFF
--- a/biobalm/_sd_algorithms/expand_source_SCCs.py
+++ b/biobalm/_sd_algorithms/expand_source_SCCs.py
@@ -1,41 +1,29 @@
 from __future__ import annotations
 
 import itertools as it
-import sys
 from typing import TYPE_CHECKING, Callable, cast
 
-from biodivine_aeon import BooleanNetwork, SymbolicContext
-
-from biobalm._sd_algorithms.expand_bfs import expand_bfs
-from biobalm.space_utils import percolate_network, percolate_space
+from biobalm.space_utils import percolate_network
 from biobalm.types import BooleanSpace
+from biobalm.interaction_graph_utils import source_nodes
 
 if TYPE_CHECKING:
     from biobalm.succession_diagram import SuccessionDiagram
 
-    ExpanderFunctionType = Callable[
-        [SuccessionDiagram, int | None, int | None, int | None],
-        bool,
-    ]
-
-sys.path.append(".")
-
-DEBUG = False
+    ExpanderFunctionType = Callable[[SuccessionDiagram], bool]
 
 
 def expand_source_SCCs(
     sd: SuccessionDiagram,
-    expander: ExpanderFunctionType = expand_bfs,
-    check_maa: bool = True,
+    check_maa: bool,
+    recursion: int = 0,
+    expander: ExpanderFunctionType | None = None,
 ) -> bool:
     """
     1. percolate
     2. find source nodes, fix combinations and then percolate
     3. at every level, find all source SCCs, expand them
     4. when there are no more SCCs, expand in a usual way.
-
-    TODO: the function uses bfs for source SCCs and for remaining nodes.
-    it should be able to import any expansion strategy and use it.
 
     TODO: it will be rare especially for empirical models,
     but there can be source SCCs even before fixing source node combinations.
@@ -51,230 +39,231 @@ def expand_source_SCCs(
 
     """
 
+    if expander is None:
+        # By default, we recursively call the SCC expansion.
+        def default_expander(sd: SuccessionDiagram):
+            return expand_source_SCCs(sd, check_maa, recursion + 1)
+
+        expander = default_expander
+
+    if sd.config["debug"]:
+        print(
+            f"Start SD expansion using SCC decomposition on {sd.network}, recursion level {recursion}."
+        )
+
     root = sd.root()
 
-    current_level = [root]
-    next_level: list[int] = []
-    final_level: list[int] = []  # from here there are no more source SCCs
+    # Usage of sets prevents node repetition in levels (this can happen if we independently
+    # percolate to the same "downstream" node after fixing different source SCC values).
+    current_level: set[int] = set([root])
+    next_level: set[int] = set()
 
-    # percolate constant nodes
-    perc_space = percolate_space(sd.symbolic, {})
-    sd.node_data(root)["space"] = perc_space
+    # This already accounts for constant percolation.
+    node_space = sd.node_data(root)["space"]
 
     # find source nodes
-    perc_bn = percolate_network(sd.network, perc_space)
-    source_nodes = find_source_nodes(perc_bn)
+    perc_bn = percolate_network(sd.network, node_space)
+    sources = source_nodes(perc_bn)
+
+    if sd.config["debug"]:
+        print(f" > Computed source/input variable(s): {sources}")
 
     # get source nodes combinations and expand root node
-    if len(source_nodes) != 0:
-        bin_values_iter = it.product(range(2), repeat=len(source_nodes))
-        for bin_values in bin_values_iter:
-            source_comb = cast(BooleanSpace, dict(zip(source_nodes, bin_values)))
-
-            sub_space = source_comb
-            sub_space.update(perc_space)
-
-            next_level.append(sd._ensure_node(root, sub_space))  # type: ignore
-
-        sd.node_data(root)["expanded"] = True
-        sd.node_data(root)[
-            "attractor_seeds"
-        ] = []  # no need to look for attractors here
-        current_level = next_level
-        next_level = []
-
-    while len(current_level) > 0:
-        if DEBUG:
-            print(f"{current_level=}")
-
-        # each level consists of one round of fixing all source SCCs
-        for node_id in current_level:
-            sub_sds = list(sd.component_subdiagrams(node_id))
-            # if there are no more source SCCs in this node, move it to the final level
-            if not sub_sds:
-                final_level.append(node_id)
-                continue
-
-            # attach all source scc sd one by one
-            current_branches = [
-                node_id
-            ]  # this is where the scc_sd should be "attached"
-            next_branches: list[int] = []
-            for sub_network_diagram in sub_sds:
-                scc_sd, exist_maa = find_subnetwork_sd(
-                    sub_network_diagram, expander, check_maa
+    if len(sources) != 0:
+        # If there are too many source nodes, this can generate an absurdly large SD.
+        # This would be a problem even without the SCC expansion, but we can just
+        # stop the whole thing faster because we know how many nodes it generates now.
+        if 2 ** len(sources) > sd.config["max_motifs_per_node"]:
+            raise RuntimeError(
+                f"Exceeded the maximum amount of stable motifs per node ({sd.config['max_motifs_per_node']}; see `SuccessionDiagramConfiguration.max_motifs_per_node`)."
+            )
+        else:
+            if sd.config["debug"]:
+                print(
+                    f" > Expanding {len(sources)} source node into {2 ** len(sources)} SD nodes."
                 )
 
-                if exist_maa:  # we check for maa, and it exists
-                    continue
-                # add scc_sd to every single branch in the original sd
-                for branch in current_branches:
-                    new_branches = attach_scc_sd(sd, scc_sd, branch, check_maa)
-                    next_branches.extend(new_branches)
+        bin_values_iter = it.product(range(2), repeat=len(sources))
+        for bin_values in bin_values_iter:
+            valuation = cast(BooleanSpace, dict(zip(sources, bin_values)))
+            sub_space = node_space | valuation
 
-                current_branches = next_branches
-                next_branches = []
+            next_level.add(sd._ensure_node(root, sub_space))  # type: ignore
 
-            # nothing was attached
-            # This happens when there were only source SCCs with motif avoidant attractors
-            if current_branches == [node_id]:
-                final_level.append(node_id)
-            # once all the source SCCs are expanded, move on to the next level
-            # the final branches become the next level
+        # This makes the root artificially "expanded". Also, there
+        # can be no attractors here because we are just fixing the source nodes.
+        sd.node_data(root)["expanded"] = True
+        sd.node_data(root)["attractor_seeds"] = []
+        sd.node_data(root)["attractor_sets"] = []
+        current_level = next_level
+        next_level = set()
+
+    while len(current_level) > 0:
+        if sd.config["debug"]:
+            print(
+                f" > Start SCC expansion of a BFS level with {len(current_level)} node(s)."
+            )
+
+        # For each node in the current level, we expand all source SCCs and put the
+        # results into a new level.
+        for node_id in sorted(current_level):
+            source_scc_diagrams = list(sd.component_subdiagrams(node_id))
+            if sd.config["debug"]:
+                print(
+                    f" > [{node_id}] Found {len(source_scc_diagrams)} sub-diagrams while expanding node."
+                )
+
+            # If there are no source SCCs, this node is a fixed-point and we can save it
+            # into the last level (every other node has at least one source SCC).
+            if len(source_scc_diagrams) == 0:
+                if sd.config["debug"]:
+                    print(f"[{node_id}] > No source SCCs found. Node is a fixed-point.")
+                assert len(sd.node_successors(node_id, compute=True)) == 0
+                continue
+
+            # If there is only one source SCC, we can do a normal expansion to get to the next level,
+            # because the attach sub-diagram process would just expand it a copy it into node_id.
+            # Furthermore, if we want to recursively use SCC expansion in SCC expansion, we *have to*
+            # do this, otherwise we would just recursively call ourselves forver on a minimal trap spaces,
+            # since the recursion wouldn't know where to stop.
+            if len(source_scc_diagrams) == 1:
+                if sd.config["debug"]:
+                    print(f"[{node_id}] > Singe source SCCs found. Expanding normally.")
+                next_level = next_level | set(sd.node_successors(node_id, compute=True))
+                continue
+
+            attach_at_list: list[int] = [node_id]
+            for scc_diagram in source_scc_diagrams:
+                fully_expanded = expander(scc_diagram)
+                if not fully_expanded:
+                    # Something bad happened in the expander function and we can't continue.
+                    return False
+
+                if sd.config["debug"]:
+                    print(
+                        f"[{node_id}] > Source SCC diagram expanded to {len(scc_diagram)} nodes."
+                    )
+
+                # At this point, diagram is fully expanded and we can attach its
+                # nodes as the successors of `node_id`.
+                next_attach_at_list: list[int] = []
+                for attach_at in attach_at_list:
+                    next_attach_at_list += attach_scc_subdiagram(
+                        sd, scc_diagram, attach_at, check_maa
+                    )
+                attach_at_list = next_attach_at_list
+
+            if attach_at_list == [node_id]:
+                # Nothing was attached at this level. This means that all source SCCs
+                # have a trivial succession diagram where we can't further "fix" anything else.
+                # Usually, this means that we are in a minimal trap space. However, there can also
+                # be another SCC connected to the source SCCs that can still have some
+                # non-trivial trap space structure.
+                #
+                # Ideally, we should be able to "ignore" the current source SCCs and move on to the
+                # following level of SCCs (because those source SCC stay "unstable" forever), but
+                # that is currently not possible, so we just expand normally.
+                if sd.config["debug"]:
+                    print(
+                        f"[{node_id}] > No further nodes attached. Expanding normally."
+                    )
+                next_level = next_level | set(sd.node_successors(node_id, compute=True))
             else:
-                next_level.extend(current_branches)
+                # Otherwise, move everything into the next layer.
+                next_level = next_level | set(attach_at_list)
 
         current_level = next_level
-        next_level = []
+        next_level = set()
 
-    # Finally, expand the sd in a usual way.
-    # TODO: motif avoidance that is already calculated in the source SCCs should be used here somehow.
-    if DEBUG:
-        print(f"{final_level=}")
-    for node_id in final_level:
-        # These assertions should be unnecessary, but just to be sure.
-        assert not sd.node_data(node_id)["expanded"]  # expand nodes from here
-        assert (
-            sd.node_data(node_id)["attractor_seeds"] is None
-        )  # check attractors from here
-
-        # restore this once we allow all expansion algorithms to expand from a node
-        # expander(sd, node_id)
-        sd.expand_bfs(node_id)
+    if sd.config["debug"]:
+        print(
+            f" > SCC expansion terminated with {len(sd)} node(s) on recursion level {recursion}."
+        )
 
     return True
 
 
-def find_source_nodes(
-    network: BooleanNetwork, ctx: SymbolicContext | None = None
-) -> list[str]:
-    """
-    Return the "source nodes" of a `BooleanNetwork`. That is, variables whose value
-    cannot change, but is not fixed to a `true`/`false` constant.
-
-    Note that this internally uses BDD translation to detect identity functions
-    semantically rather than syntactically. If you already have a `SymbolicContext`
-    for the given `network` available, you can supply it as the second argument.
-    """
-    if ctx is None:
-        ctx = SymbolicContext(network)
-
-    result: list[str] = []
-    for var in network.variables():
-        update_function = network.get_update_function(var)
-        assert update_function is not None  # Parameters are not allowed.
-        fn_bdd = ctx.mk_update_function(update_function)
-        var_bdd = ctx.mk_network_variable(var)
-        if fn_bdd == var_bdd:
-            result.append(network.get_variable_name(var))
-
-    return result
-
-
-def find_subnetwork_sd(
-    sub_network_diagram: SuccessionDiagram,
-    expander: ExpanderFunctionType,
-    check_maa: bool,
-) -> tuple[SuccessionDiagram, bool]:
-    """
-    Computes a `SuccessionDiagram` of a particular sub-network using an expander function.
-
-    If `check_maa` is set to `True`, also checks if the resulting succession diagram admits
-    motif avoidant attractors.
-
-    Returns
-    -------
-    scc_sd - succession diagram of the source SCC
-    exist_maa - False if motif avoidance is not checked, or if motif avoidance does not exist
-                True if there is motif avoidance
-
-    """
-    fully_expanded = expander(sub_network_diagram, None, None, None)
-    assert fully_expanded
-
-    has_maa = False
-    if check_maa:
-        # check for motif avoidant attractors
-        # TODO: somehow skip this calculation when this source SCC appears again later.
-        # it will appear again, since souce SCC with maa are not fixed.
-        motif_avoidant_count = 0
-        for node in sub_network_diagram.node_ids():
-            attr = sub_network_diagram.node_attractor_seeds(node, compute=True)
-            if not sub_network_diagram.node_is_minimal(node):
-                motif_avoidant_count += len(attr)
-        if motif_avoidant_count != 0:
-            # ignore source SCCs with motif avoidant attractors
-            has_maa = True
-
-    return sub_network_diagram, has_maa
-
-
-def attach_scc_sd(
-    sd: SuccessionDiagram,
-    scc_sd: SuccessionDiagram,
-    branch: int,
-    check_maa: bool,
+def attach_scc_subdiagram(
+    sd: SuccessionDiagram, scc_sd: SuccessionDiagram, attach_at: int, check_maa: bool
 ) -> list[int]:
     """
-    Attach scc_sd to the given branch point of the sd.
-    Returns the new branching points.
+    Attach the `scc_sd` to the `attach_at` node of `sd`.
+
+    This means that every node of `scc_sd` will be extended to the full context of `sd`
+    and attached as if `attach_at` was the root of `scc_sd`.
+
+    If `check_maa` is set to `True`, the method will also check `scc_sd` for motif-avoidant
+    attractors and if MAAs are disproven, the corresponding nodes of `sd` will be also marked
+    as not having any MAAs.
 
     Parameters
     ----------
-    check_maa - If true, it is assumed that scc_sd is already checked
-                to not have motif avoidant attractors.
-                Make sure only give scc_sd with no maa
+    sd - The main succession diagram into which we are attaching the `scc_sd`.
+    scc_sd - A component subdiagram which will be copied into `sd`.
+    attach_at - A node id from `sd` that will be used as the virtual "root" of `scc_sd` while attaching.
+    check_maa - A flag that indicates that MAAs absence information should be propagated from the `scc_sd`
+                to the main `sd`.
+
+    Returns
+    -------
+    The IDs of `sd` nodes that correspond to the minimal trap spaces of `scc_sd`.
     """
+
     if len(scc_sd) == 1:
-        return [branch]
+        # This `scc_sd` has a single minimal SCC, which thus corresponds to the `attach_at` point.
+        return [attach_at]
 
-    next_branches: list[int] = []
-    size_before_attach = sd.dag.number_of_nodes()
-    # first add all the nodes using their first parent
+    # Maps node IDs from the `scc_sd` to the extended and copied nodes in `sd`.
+    node_id_map: dict[int, int] = {scc_sd.root(): attach_at}
+
+    attach_at_space = sd.node_data(attach_at)["space"]
+
+    # First, copy every node from `scc_sd`` into main `sd`.
+    min_traps: list[int] = []
     for scc_node_id in scc_sd.node_ids():
-        if scc_node_id == 0:  # no need to add the root of scc_sd
-            continue
+        if scc_node_id == scc_sd.root():
+            continue  # Root is implicitly copied.
 
-        scc_parent_id = cast(
-            int,
-            list(scc_sd.dag.predecessors(scc_node_id))[0],  # type: ignore
-        )  # get the first parent
-        assert scc_parent_id < scc_node_id
+        scc_node_space = scc_sd.node_data(scc_node_id)["space"]
+        extended_node_space = scc_node_space | attach_at_space
 
-        if scc_parent_id == 0:  # the parent is the root of scc_sd
-            parent_id = branch
+        main_node_id = sd._ensure_node(parent_id=None, stable_motif=extended_node_space)  # type: ignore
+        node_id_map[scc_node_id] = main_node_id
+
+        if scc_sd.node_is_minimal(scc_node_id):
+            min_traps.append(main_node_id)
         else:
-            parent_id = size_before_attach + scc_parent_id - 1
+            # This node can be marked as expanded, because we know its successors.
+            # We just need to add them in the for loop below.
+            sd.node_data(main_node_id)["expanded"] = True
 
-        motif = scc_sd.edge_stable_motif(scc_parent_id, scc_node_id)
-        motif.update(cast(BooleanSpace, sd.dag.nodes[branch]["space"]))
-
-        child_id = sd._ensure_node(parent_id, motif)  # type: ignore
         if check_maa:
-            sd.dag.nodes[parent_id][
-                "attractors"
-            ] = []  # no need to check for attractors in these nodes
+            if len(scc_sd.node_attractor_candidates(scc_node_id, compute=True)) == 0:
+                sd.node_data(main_node_id)["attractor_seeds"] = []
+                sd.node_data(main_node_id)["attractor_sets"] = []
 
-        if scc_sd.node_is_minimal(scc_node_id) and child_id not in next_branches:
-            next_branches.append(child_id)
+    assert len(node_id_map) == len(scc_sd)
 
-    # now add all the missing edges
+    # Then copy all the edges.
     for scc_node_id in scc_sd.node_ids():
-        if scc_node_id == 0:
-            parent_id = branch
-        else:
-            parent_id = size_before_attach + scc_node_id - 1
+        for scc_node_succ in scc_sd.node_successors(scc_node_id):
+            inner_stable_motif = scc_sd.edge_stable_motif(scc_node_id, scc_node_succ)
 
-        scc_child_ids = cast(list[int], list(scc_sd.dag.successors(scc_node_id)))  # type: ignore
-        for scc_child_id in scc_child_ids:
-            motif = scc_sd.edge_stable_motif(scc_node_id, scc_child_id)
-            motif.update(cast(BooleanSpace, sd.dag.nodes[branch]["space"]))
+            main_node_id = node_id_map[scc_node_id]
+            main_succ_id = node_id_map[scc_node_succ]
 
-            child_id = sd._ensure_node(parent_id, motif)  # type: ignore
-            assert child_id == size_before_attach + scc_child_id - 1
+            # This should not happen, because the source SCCs are independent.
+            # But I don't have a formal proof.
+            assert main_node_id != main_succ_id
 
-        # if the node had any child node, consider it expanded.
-        if len(scc_child_ids) > 0:
-            sd.dag.nodes[parent_id]["expanded"] = True
+            sd._ensure_edge(main_node_id, main_succ_id, inner_stable_motif)  # type: ignore
 
-    return next_branches
+    # This makes the `attach_at` node expanded. We will not be adding new nodes to it later.
+    sd.node_data(attach_at)["expanded"] = True
+    # Finally, if we are checking for MAAs, we can do that for the root too:
+    if check_maa:
+        if len(scc_sd.node_attractor_candidates(scc_sd.root(), compute=True)) == 0:
+            sd.node_data(attach_at)["attractor_seeds"] = []
+            sd.node_data(attach_at)["attractor_sets"] = []
+
+    return min_traps

--- a/biobalm/_sd_algorithms/expand_source_SCCs.py
+++ b/biobalm/_sd_algorithms/expand_source_SCCs.py
@@ -107,7 +107,7 @@ def expand_source_SCCs(
         # For each node in the current level, we expand all source SCCs and put the
         # results into a new level.
         for node_id in sorted(current_level):
-            source_scc_diagrams = list(sd.component_subdiagrams(node_id))
+            source_scc_diagrams = list(sd.source_scc_subdiagrams(node_id))
             if sd.config["debug"]:
                 print(
                     f" > [{node_id}] Found {len(source_scc_diagrams)} sub-diagrams while expanding node."

--- a/biobalm/_sd_algorithms/expand_source_blocks.py
+++ b/biobalm/_sd_algorithms/expand_source_blocks.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import itertools as it
+from typing import TYPE_CHECKING, cast
+
+from biobalm.space_utils import percolate_network
+from biobalm.types import BooleanSpace
+from biobalm.interaction_graph_utils import source_nodes
+
+if TYPE_CHECKING:
+    from biobalm.succession_diagram import SuccessionDiagram
+
+
+def expand_source_blocks(
+    sd: SuccessionDiagram,
+    check_maa: bool = True,
+) -> bool:
+    """
+    Base correctness assumptions:
+
+     - Expanding two minimal blocks is always independent.
+     -
+    """
+
+    if sd.config["debug"]:
+        print(f"Start SD expansion using block decomposition on {sd.network}.")
+
+    root = sd.root()
+
+    current_level: set[int] = set([root])
+    next_level: set[int] = set()
+
+    # This already accounts for constant percolation.
+    node_space = sd.node_data(root)["space"]
+
+    # find source nodes
+    perc_bn = percolate_network(sd.network, node_space)
+    sources = source_nodes(perc_bn)
+
+    if sd.config["debug"]:
+        print(f" > Computed source/input variable(s): {sources}")
+
+    # get source nodes combinations and expand root node
+    if len(sources) != 0:
+        # If there are too many source nodes, this can generate an absurdly large SD.
+        # This would be a problem even without the SCC expansion, but we can just
+        # stop the whole thing faster because we know how many nodes it generates.
+        if 2 ** len(sources) > sd.config["max_motifs_per_node"]:
+            raise RuntimeError(
+                f"Exceeded the maximum amount of stable motifs per node ({sd.config['max_motifs_per_node']}; see `SuccessionDiagramConfiguration.max_motifs_per_node`)."
+            )
+        else:
+            if sd.config["debug"]:
+                print(
+                    f" > Expanding {len(sources)} source node into {2 ** len(sources)} SD nodes."
+                )
+
+        bin_values_iter = it.product(range(2), repeat=len(sources))
+        for bin_values in bin_values_iter:
+            valuation = cast(BooleanSpace, dict(zip(sources, bin_values)))
+            sub_space = node_space | valuation
+
+            next_level.add(sd._ensure_node(root, sub_space))  # type: ignore
+
+        # This makes the root artificially "expanded". Also, there
+        # can be no attractors here because we are just fixing the source nodes.
+        sd.node_data(root)["expanded"] = True
+        sd.node_data(root)["attractor_seeds"] = []
+        sd.node_data(root)["attractor_sets"] = []
+        current_level = next_level
+        next_level = set()
+
+    bfs_depth = 0
+
+    while len(current_level) > 0:
+        bfs_depth += 1
+        if sd.config["debug"]:
+            print(
+                f" > Start block expansion of a BFS level {bfs_depth} with {len(current_level)} node(s)."
+            )
+
+        for node in sorted(current_level):  # Sorted for determinism
+            if sd.node_data(node)["expanded"]:
+                # We re-discovered a previously expanded node.
+                continue
+
+            # Compute successors as if this was a normal expansion procedure.
+            successors = sd.node_successors(node, compute=True)
+            # Sort successors to avoid non-determinism.
+            successors = sorted(successors)
+
+            if len(successors) == 0:
+                # This is a minimal trap space.
+                continue
+
+            if len(successors) == 1 and not check_maa:
+                # This space is not minimal, but there is no "choice" to make here.
+                # We can just continue with that single choice.
+                #
+                # However, if we are checking for MAAs, we continue as normal, because
+                # we need to compute most of the non-trivial results anyway.
+
+                next_level.add(successors[0])
+                continue
+
+            node_bn = sd.node_percolated_network(node, compute=True)
+
+            # Split successors into "blocks" based on the regulatory component
+            # of the variables fixed by the stable motif.
+
+            # Maps a "block" (bwd-closed set of variables) to a list of node IDs (successor nodes).
+            blocks: list[tuple[set[str], list[int]]] = []
+            for s in successors:
+                motif = sd.edge_stable_motif(node, s, reduced=True)
+                motif_block = node_bn.backward_reachable(list(motif.keys()))
+                motif_block_names = {node_bn.get_variable_name(v) for v in motif_block}
+
+                found = False
+                for block, nodes in blocks:
+                    if block == motif_block_names:
+                        found = True
+                        nodes.append(s)
+                        break
+                if not found:
+                    blocks.append((motif_block_names, [s]))
+
+            if sd.config["debug"]:
+                print(
+                    f" > [{node}] Computed blocks: {[(len(k), len(v)) for (k, v) in blocks]}"
+                )
+
+            # Now remove all non-minimal blocks (minimal in terms of set inclusion).
+            # The reason why we are removing those is that they are not independent
+            # on the minimal blocks.
+
+            minimal_blocks: list[tuple[set[str], list[int]]] = []
+            if len(blocks) > 1:
+                for block, nodes in blocks:
+                    is_minimal = True
+                    for b2, _ in blocks:
+                        if b2 < block:
+                            is_minimal = False
+                            break
+                    if is_minimal:
+                        minimal_blocks.append((block, nodes))
+            else:
+                minimal_blocks = blocks
+
+            # Sort minimal blocks by the number of successor nodes (we want to pick
+            # the one that leads leads to the minimal SD expansion).
+            minimal_blocks = sorted(minimal_blocks, key=lambda x: len(x[1]))
+
+            if sd.config["debug"]:
+                print(
+                    f" > [{node}] Minimal blocks: {[(len(k), len(v)) for (k, v) in minimal_blocks]}"
+                )
+
+            # We will expand all nodes that are in the smallest block.
+            to_expand = minimal_blocks[0][1]
+
+            if sd.config["debug"]:
+                print(f" > [{node}] Final block ({len(to_expand)}): {to_expand}")
+
+            next_level = next_level | set(to_expand)
+
+            if check_maa:
+                # If we are checking for MAAs, it is sufficient to check the succession diagram
+                # that is induced by the chosen block. Every state that eventually always reaches
+                # one of the subspaces in the smaller network will do so in the larger network as
+                # well, since these trajectories can be repeated exactly as they do not depend
+                # on any of the other network variables.
+                chosen_block = minimal_blocks[0][0]
+                block_sd = sd.component_subdiagram(list(chosen_block), node)
+
+                # The succession diagram "restricted" to our chosen block should have
+                # the same (restricted) successor nodes.
+                assert len(
+                    block_sd.node_successors(block_sd.root(), compute=True)
+                ) == len(to_expand)
+
+                # We could also consider using `seeds` instead of `candidates` here. Ultimately, this
+                # matters very rarely. The reasoning for why we use `candidates` is that we can (almost)
+                # always guarantee that the expansion is going to finish, even if some nodes do not
+                # have their MAAs eliminated. As such, one can try to use other techniques to disprove
+                # MAAs in the problematic nodes while using the nice properties of the expansion to
+                # still disprove MAAs in the remaining nodes. If we used `seeds`, the expansion could
+                # just get stuck on this node and the "partial" results wouldn't be usable.
+                block_sd_candidates = block_sd.node_attractor_candidates(
+                    block_sd.root(), compute=True
+                )
+                if len(block_sd_candidates) == 0:
+                    if sd.config["debug"]:
+                        print(
+                            f"[{node}] > Motif-avoidant attractors ruled out based on the sub-diagram."
+                        )
+                    sd.node_data(node)["attractor_seeds"] = []
+                    sd.node_data(node)["attractor_sets"] = []
+                else:
+                    if sd.config["debug"]:
+                        print(
+                            f"[{node}] > Cannot rule out MAA attractors. Found {len(block_sd_candidates)} candidates."
+                        )
+
+        current_level = next_level
+        next_level = set()
+
+    if sd.config["debug"]:
+        print(f" > Block expansion terminated with {len(sd)} node(s).")
+
+    return True

--- a/biobalm/_sd_algorithms/expand_source_blocks.py
+++ b/biobalm/_sd_algorithms/expand_source_blocks.py
@@ -169,7 +169,7 @@ def expand_source_blocks(
                 # can be either in this node, or in any of the child nodes. If a clean block
                 # is found, we know that it is safe to expand it without "missing" any MAAs.
                 clean_block_found = False
-                for (block, block_nodes) in minimal_blocks:
+                for block, block_nodes in minimal_blocks:
                     block_sd = sd.component_subdiagram(list(block), node)
 
                     # The succession diagram "restricted" to the considered block should have
@@ -190,7 +190,9 @@ def expand_source_blocks(
                     )
                     if len(block_sd_candidates) == 0:
                         if sd.config["debug"]:
-                            print(f" > [{node}] Found clean block with no MAAs ({len(block_nodes)}): {block_nodes}")
+                            print(
+                                f" > [{node}] Found clean block with no MAAs ({len(block_nodes)}): {block_nodes}"
+                            )
                         clean_block_found = True
                         next_level = next_level | set(block_nodes)
                         sd.node_data(node)["attractor_seeds"] = []
@@ -204,7 +206,9 @@ def expand_source_blocks(
                 if not clean_block_found:
                     # If all blocks have MAAs, we expand all successors.
                     if sd.config["debug"]:
-                        print(f" > [{node}] No clean block found. Expanding all {len(successors)} successors.")
+                        print(
+                            f" > [{node}] No clean block found. Expanding all {len(successors)} successors."
+                        )
                     next_level = next_level | set(successors)
 
         current_level = next_level

--- a/biobalm/_sd_attractors/attractor_candidates.py
+++ b/biobalm/_sd_attractors/attractor_candidates.py
@@ -302,18 +302,22 @@ def compute_attractor_candidates(
 
                 # At this point, we know the candidate count increased and so we should
                 # try to bring it back down.
-                if sd.config["debug"]:
-                    print(f"[{node_id}] Optimizing partial retained set...")
-                optimized = asp_greedy_retained_set_optimization(
-                    sd,
-                    node_id,
-                    petri_net=pn_reduced,
-                    retained_set=retained_set,
-                    candidate_states=candidate_states,
-                    avoid_dnf=child_motifs_reduced,
-                )
-                retained_set = optimized[0]
-                candidate_states = optimized[1]
+                if (
+                    len(candidate_states)
+                    > sd.config["retained_set_optimization_threshold"]
+                ):
+                    if sd.config["debug"]:
+                        print(f"[{node_id}] Optimizing partial retained set...")
+                    optimized = asp_greedy_retained_set_optimization(
+                        sd,
+                        node_id,
+                        petri_net=pn_reduced,
+                        retained_set=retained_set,
+                        candidate_states=candidate_states,
+                        avoid_dnf=child_motifs_reduced,
+                    )
+                    retained_set = optimized[0]
+                    candidate_states = optimized[1]
 
     # Terminate if done.
     if len(candidate_states) == 0:

--- a/biobalm/_sd_attractors/attractor_candidates.py
+++ b/biobalm/_sd_attractors/attractor_candidates.py
@@ -347,8 +347,10 @@ def compute_attractor_candidates(
         # the candidate set is being actively reduced. If the simulation
         # cannot reduce any further states and exceeds the proposed budget,
         # we are done.
-        iterations = 2 ** 10
-        max_budget = sd.config["minimum_simulation_budget"] * bn_reduced.variable_count()
+        iterations = 2**10
+        max_budget = (
+            sd.config["minimum_simulation_budget"] * bn_reduced.variable_count()
+        )
         while len(candidate_states) > 0:
             if sd.config["debug"]:
                 print(
@@ -364,7 +366,10 @@ def compute_attractor_candidates(
                 simulation_seed=123,
             )
 
-            if len(reduced) == len(candidate_states) and (iterations * len(candidate_states)) > max_budget:
+            if (
+                len(reduced) == len(candidate_states)
+                and (iterations * len(candidate_states)) > max_budget
+            ):
                 candidate_states = reduced
                 break
 

--- a/biobalm/_sd_attractors/attractor_candidates.py
+++ b/biobalm/_sd_attractors/attractor_candidates.py
@@ -345,8 +345,9 @@ def compute_attractor_candidates(
 
         # Here, we gradually increase the iteration count while
         # the candidate set is being actively reduced. If the simulation
-        # cannot reduce any further states, we are done.
-        iterations = 1024
+        # cannot reduce any further states and exceeds the proposed budget,
+        # we are done.
+        iterations = 2 ** 10
         while len(candidate_states) > 0:
             if sd.config["debug"]:
                 print(
@@ -362,7 +363,7 @@ def compute_attractor_candidates(
                 simulation_seed=123,
             )
 
-            if len(reduced) == len(candidate_states):
+            if len(reduced) == len(candidate_states) and (iterations * len(candidate_states)) > sd.config["minimum_simulation_budget"]:
                 candidate_states = reduced
                 break
 

--- a/biobalm/_sd_attractors/attractor_candidates.py
+++ b/biobalm/_sd_attractors/attractor_candidates.py
@@ -348,6 +348,7 @@ def compute_attractor_candidates(
         # cannot reduce any further states and exceeds the proposed budget,
         # we are done.
         iterations = 2 ** 10
+        max_budget = sd.config["minimum_simulation_budget"] * bn_reduced.variable_count()
         while len(candidate_states) > 0:
             if sd.config["debug"]:
                 print(
@@ -363,7 +364,7 @@ def compute_attractor_candidates(
                 simulation_seed=123,
             )
 
-            if len(reduced) == len(candidate_states) and (iterations * len(candidate_states)) > sd.config["minimum_simulation_budget"]:
+            if len(reduced) == len(candidate_states) and (iterations * len(candidate_states)) > max_budget:
                 candidate_states = reduced
                 break
 

--- a/biobalm/interaction_graph_utils.py
+++ b/biobalm/interaction_graph_utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 from typing import cast
 
-from biodivine_aeon import BooleanNetwork, RegulatoryGraph, SymbolicContext, SignType
+from biodivine_aeon import BooleanNetwork, RegulatoryGraph, SignType, SymbolicContext
 from networkx import DiGraph  # type: ignore
 
 
@@ -187,12 +187,28 @@ def source_nodes(
     network: BooleanNetwork, ctx: SymbolicContext | None = None
 ) -> list[str]:
     """
-    Return the source nodes of a `BooleanNetwork`. That is, variables whose value
-    cannot change, but is not fixed to a `true`/`false` constant.
+    Identify the source nodes of a given `BooleanNetwork`.
+
+    Return the source nodes of a `BooleanNetwork`. That is, variables whose
+    value cannot change, but is not fixed to a `true`/`false` constant.
 
     Note that this internally uses BDD translation to detect identity functions
-    semantically rather than syntactically. If you already have a `SymbolicContext`
-    for the given `network` available, you can supply it as the second argument.
+    semantically rather than syntactically. If you already have a
+    `SymbolicContext` for the given `network` available, you can supply it as
+    the second argument.
+
+    Parameters
+    ----------
+    network : BooleanNetwork
+        The Boolean network to be examined.
+    ctx : SymbolicContext
+        The context used to translate the network to BDDs. A
+        `biodivine_aeon.SymbolicContext` object.
+
+    Returns
+    -------
+    list[str]
+        The list of source nodes.
     """
     if ctx is None:
         ctx = SymbolicContext(network)

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -19,6 +19,7 @@ from biobalm._sd_algorithms.expand_bfs import expand_bfs
 from biobalm._sd_algorithms.expand_dfs import expand_dfs
 from biobalm._sd_algorithms.expand_minimal_spaces import expand_minimal_spaces
 from biobalm._sd_algorithms.expand_source_SCCs import expand_source_SCCs
+from biobalm._sd_algorithms.expand_source_blocks import expand_source_blocks
 from biobalm._sd_algorithms.expand_to_target import expand_to_target
 
 from biobalm.interaction_graph_utils import (
@@ -1187,6 +1188,12 @@ class SuccessionDiagram:
         Expand the succession diagram using the source SCC method.
         """
         return expand_source_SCCs(self, check_maa=find_motif_avoidant_attractors)
+
+    def expand_block(self, find_motif_avoidant_attractors: bool = True) -> bool:
+        """
+        Expand the succession diagram using the source block method.
+        """
+        return expand_source_blocks(self, find_motif_avoidant_attractors)
 
     def expand_bfs(
         self,

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -175,7 +175,7 @@ class SuccessionDiagram:
             "pint_goal_size_limit": 8_192,
             "attractor_candidates_limit": 100_000,
             "retained_set_optimization_threshold": 1_000,
-            "minimum_simulation_budget": 1_000_000,
+            "minimum_simulation_budget": 1_000,
         }
 
     @staticmethod

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1094,33 +1094,33 @@ class SuccessionDiagram:
             return cast(BooleanSpace, self.dag.edges[parent_id, child_id]["motif"])
 
     def component_subdiagram(
-            self,
-            component_variables: list[str],
-            node_id: int | None = None,
+        self,
+        component_variables: list[str],
+        node_id: int | None = None,
     ) -> SuccessionDiagram:
         """
-        Return an *unexpanded* `SuccessionDiagram` that is restricted to 
+        Return an *unexpanded* `SuccessionDiagram` that is restricted to
         a subnetwork induced by the provided `component_variables`.  Furthermore,
         If `node_id` is given, the subnetwork is first percolated to the
         subspace of the specified node.
-        
+
         The `component_variables` must be backward-closed in the considered network
-        (i.e. either the full network, or the percolated network if `node_id` is given), 
+        (i.e. either the full network, or the percolated network if `node_id` is given),
         meaning there is no variable outside this list that regulates any variable in the
-        subnetwork. If this is not satisfied, the function will fail while 
+        subnetwork. If this is not satisfied, the function will fail while
         creating the subnetwork.
 
         Also note that the symbolic encoding of the new network is not
         compatible with the encoding of the original network, because the
         underlying networks have different sets of variables.
-        
+
         Parameters
         ----------
         component_variables : list[str]
             Names of variables which induce the subnetwork of the resulting
-            succession diagram. 
+            succession diagram.
         node_id : int | None
-            The ID of a succession diagram node that will define a subspace 
+            The ID of a succession diagram node that will define a subspace
             to which the subnetwork is percolated. If not given, the full
             network is considered.
 
@@ -1134,11 +1134,12 @@ class SuccessionDiagram:
         if node_id is not None:
             network = self.node_percolated_network(node_id, compute=True)
 
-        to_remove = [ v for v in network.variable_names() if v not in component_variables ]
+        to_remove = [
+            v for v in network.variable_names() if v not in component_variables
+        ]
         component_bn = network.drop(to_remove)
         config_copy: SuccessionDiagramConfiguration = copy.copy(self.config)
         return SuccessionDiagram(component_bn, config_copy)
-
 
     def source_scc_subdiagrams(
         self,
@@ -1172,7 +1173,7 @@ class SuccessionDiagram:
 
         for component_variables in source_scc_list:
             yield self.component_subdiagram(component_variables, node_id)
-            
+
     def build(self):
         """
         Expand the succession diagram and search for attractors using default methods.

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -175,6 +175,7 @@ class SuccessionDiagram:
             "pint_goal_size_limit": 8_192,
             "attractor_candidates_limit": 100_000,
             "retained_set_optimization_threshold": 1_000,
+            "minimum_simulation_budget": 1_000_000,
         }
 
     @staticmethod

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1192,6 +1192,12 @@ class SuccessionDiagram:
     def expand_block(self, find_motif_avoidant_attractors: bool = True) -> bool:
         """
         Expand the succession diagram using the source block method.
+
+        There is a minor difference in behavior depending on `find_motif_avoidant_attractors`.
+        If set to `False`, the expansion only expands one "source block" for each node,
+        without checking any attractor properties. If set to `True`, the expansion might
+        expand some nodes fully to uncover nodes that precisely cover motif
+        avoidant attractors.
         """
         return expand_source_blocks(self, find_motif_avoidant_attractors)
 

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -231,8 +231,10 @@ class SuccessionDiagramConfiguration(TypedDict):
 
     minimum_simulation_budget: int
     """
-    The minimum number of simulation steps that is guaranteed to be spent on eliminating
-    attractor candidate states.
+    The minimum number of simulation steps per network variable that is guaranteed to be 
+    spent on eliminating attractor candidate states. That is, if budget is `1_000` and
+    the network has `200` variables, the total number of allowed 
+    simulation steps is `200_000`.
 
     Note that this is a budget that applies to all candidates collectively. So if the number
     of candidates is larger, the number of steps per candidate is proportionally smaller. 

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -231,14 +231,14 @@ class SuccessionDiagramConfiguration(TypedDict):
 
     minimum_simulation_budget: int
     """
-    The minimum number of simulation steps per network variable that is guaranteed to be 
+    The minimum number of simulation steps per network variable that is guaranteed to be
     spent on eliminating attractor candidate states. That is, if budget is `1_000` and
-    the network has `200` variables, the total number of allowed 
+    the network has `200` variables, the total number of allowed
     simulation steps is `200_000`.
 
     Note that this is a budget that applies to all candidates collectively. So if the number
-    of candidates is larger, the number of steps per candidate is proportionally smaller. 
+    of candidates is larger, the number of steps per candidate is proportionally smaller.
     However, this budget only applies when simulation has not been able to make progress
-    in the recent round. That is, if simulation has actively eliminated some candidates in 
+    in the recent round. That is, if simulation has actively eliminated some candidates in
     the recent round, it will still continue regardless of the budget limit.
     """

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -228,3 +228,15 @@ class SuccessionDiagramConfiguration(TypedDict):
     If there are more than this amount of attractor candidates, the attractor
     detection process will try to optimize the retained set using ASP (if enabled).
     """
+
+    minimum_simulation_budget: int
+    """
+    The minimum number of simulation steps that is guaranteed to be spent on eliminating
+    attractor candidate states.
+
+    Note that this is a budget that applies to all candidates collectively. So if the number
+    of candidates is larger, the number of steps per candidate is proportionally smaller. 
+    However, this budget only applies when simulation has not been able to make progress
+    in the recent round. That is, if simulation has actively eliminated some candidates in 
+    the recent round, it will still continue regardless of the budget limit.
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    'biodivine_aeon ==1.0.0a6',
+    'biodivine_aeon ==1.0.0a8',
     'clingo >=5.6.2',
     'networkx >=2.8.8',    
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ astroid==3.1.0
 autodocsumm==0.2.12
 Babel==2.14.0
 beautifulsoup4==4.12.3
-biodivine_aeon==1.0.0a4
+biodivine_aeon==1.0.0a8
 black==24.2.0
 boolean.py==4.0
 CacheControl==0.14.0
@@ -17,6 +17,7 @@ charset-normalizer==3.3.2
 click==8.1.7
 clingo==5.6.2
 colomoto-jupyter==0.8.8
+coverage==7.4.2
 cssutils==2.9.0
 dict2css==0.3.0.post1
 docutils==0.20.1
@@ -26,6 +27,7 @@ flake8==7.0.0
 html5lib==1.1
 idna==3.6
 imagesize==1.4.1
+iniconfig==2.0.0
 Jinja2==3.1.3
 MarkupSafe==2.1.5
 mccabe==0.7.0
@@ -39,6 +41,7 @@ packaging==23.2
 pandas==2.2.1
 pathspec==0.12.1
 platformdirs==4.2.0
+pluggy==1.4.0
 pyarrow==15.0.0
 pycodestyle==2.11.1
 pycparser==2.21
@@ -48,6 +51,8 @@ pyflakes==3.2.0
 Pygments==2.17.2
 pyparsing==3.1.1
 pypint==1.6.2
+pytest==8.0.1
+pytest-cov==4.1.0
 python-dateutil==2.8.2
 pytz==2024.1
 PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biodivine_aeon==1.0.0a6
+biodivine_aeon==1.0.0a8
 clingo==5.6.2
 networkx==2.8.8
 pypint[pint]==1.6.2

--- a/tests/source_SCC_test.py
+++ b/tests/source_SCC_test.py
@@ -3,6 +3,7 @@ from biodivine_aeon import BooleanNetwork
 from biobalm import SuccessionDiagram
 from biobalm._sd_algorithms.expand_source_SCCs import expand_source_SCCs
 
+
 def expansion(bn: BooleanNetwork):
     sd = SuccessionDiagram(bn)
     fully_expanded = expand_source_SCCs(sd, check_maa=False)

--- a/tests/source_block_test.py
+++ b/tests/source_block_test.py
@@ -1,14 +1,13 @@
 from biodivine_aeon import BooleanNetwork
 
 from biobalm import SuccessionDiagram
-from biobalm._sd_algorithms.expand_source_SCCs import expand_source_SCCs
 
 def expansion(bn: BooleanNetwork):
     sd = SuccessionDiagram(bn)
-    fully_expanded = expand_source_SCCs(sd, check_maa=False)
+    fully_expanded = sd.expand_block(find_motif_avoidant_attractors=False)
     assert fully_expanded
 
-    return bn.variable_count(), len(sd), sd.depth(), len(sd.minimal_trap_spaces())
+    return bn.variable_count(), len(sd), len(list(sd.expanded_ids())), sd.depth(), len(sd.minimal_trap_spaces())
 
 
 def test_expansion():
@@ -19,9 +18,10 @@ def test_expansion():
     B, !A & !B | C
     C, A & B"""
     )
-    n, size, depth, min = expansion(bn)
+    n, size, e_size, depth, min = expansion(bn)
     assert n == 3
     assert size == 2
+    assert e_size == 2
     assert depth == 1
     assert min == 1
 
@@ -32,9 +32,10 @@ def test_expansion():
     B, !A | (A & B & C)
     C, !B | (A & B & C)"""
     )
-    n, size, depth, min = expansion(bn)
+    n, size, e_size, depth, min = expansion(bn)
     assert n == 3
     assert size == 2
+    assert e_size == 2
     assert depth == 1
     assert min == 1
 
@@ -48,26 +49,27 @@ def test_expansion():
     Y, !X | (X & Y & Z)
     Z, !Y | (X & Y & Z)"""
     )
-    n, size, depth, min = expansion(bn)
+    n, size, e_size, depth, min = expansion(bn)
     assert n == 6
-    assert size == 3
+    assert size == 4
+    assert e_size == 3
     assert depth == 2
     assert min == 1
 
     # real bnet
     bn = BooleanNetwork.from_file("models/bbm-bnet-inputs-true/002.bnet")
-    _, _, _, min = expansion(bn)
+    _, _, _, _, min = expansion(bn)
     assert min == 24
 
 
 def attractor_search(bn: BooleanNetwork):
     sd = SuccessionDiagram(bn)
-    fully_expanded = sd.expand_scc()
+    fully_expanded = sd.expand_block(find_motif_avoidant_attractors=True)
     assert fully_expanded
 
     attractor_count = 0
     motif_avoidant_count = 0
-    for node in sd.node_ids():
+    for node in sd.expanded_ids():
         attr = sd.node_attractor_seeds(node, compute=True)
         attractor_count += len(attr)
         if not sd.node_is_minimal(node):
@@ -76,6 +78,7 @@ def attractor_search(bn: BooleanNetwork):
     return (
         bn.variable_count(),
         len(sd),
+        len(list(sd.expanded_ids())),
         sd.depth(),
         attractor_count,
         motif_avoidant_count,
@@ -95,9 +98,10 @@ def test_attractor_search():
     source_after_perc, source_after_perc & constant1_1
     after_perc_0, after_perc_0 & constant1_0"""
     )
-    N, size, depth, att, maa, min = attractor_search(bn)
+    N, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert N == 8
     assert size == 5
+    assert e_size == 5
     assert depth == 1
     assert att == 4
     assert maa == 0
@@ -109,9 +113,10 @@ def test_attractor_search():
     source2, source2
     oscillator, !oscillator"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 3
     assert size == 5
+    assert e_size == 5
     assert depth == 1
     assert att == 4
     assert maa == 0
@@ -121,9 +126,10 @@ def test_attractor_search():
         """targets,factors
     constant, true"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 1
     assert size == 1
+    assert e_size == 1
     assert depth == 0
     assert att == 1
     assert maa == 0
@@ -133,9 +139,10 @@ def test_attractor_search():
         """targets,factors
     oscillator, !oscillator"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 1
     assert size == 1
+    assert e_size == 1
     assert depth == 0
     assert att == 1
     assert maa == 0
@@ -150,9 +157,10 @@ def test_attractor_search():
     C, D & source2
     D, C"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 6
-    assert size == 15
+    assert size == 17
+    assert e_size == 15
     assert depth == 3
     assert att == 9
     assert maa == 0
@@ -167,9 +175,10 @@ def test_attractor_search():
     C, D & source2
     D, C"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 6
-    assert size == 15
+    assert size == 17
+    assert e_size == 15
     assert depth == 3
     assert att == 9
     assert maa == 0
@@ -182,9 +191,10 @@ def test_attractor_search():
     B, !A & !B | C
     C, A & B"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 3
     assert size == 2
+    assert e_size == 2
     assert depth == 1
     assert att == 2
     assert maa == 1
@@ -197,9 +207,10 @@ def test_attractor_search():
     B, !A | (A & B & C)
     C, !B | (A & B & C)"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 3
     assert size == 2
+    assert e_size == 2
     assert depth == 1
     assert att == 2
     assert maa == 1
@@ -215,9 +226,10 @@ def test_attractor_search():
     Y, !X | (X & Y & Z)
     Z, !Y | (X & Y & Z)"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 6
-    assert size == 3
+    assert size == 4
+    assert e_size == 4
     assert depth == 2
     assert att == 4
     assert maa == 3
@@ -233,9 +245,10 @@ def test_attractor_search():
     B, !A & !B | C
     C, A & B & source"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 6
-    assert size == 6
+    assert size == 8
+    assert e_size == 7
     assert depth == 3
     assert att == 5
     assert maa == 2
@@ -258,9 +271,10 @@ def test_attractor_search():
     X3, Y3 & X2
     Y3, X3"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert n == 13
-    assert size == 28
+    assert size == 75
+    assert e_size == 41
     assert depth == 6
     assert att == 28
     assert maa == 14
@@ -268,14 +282,14 @@ def test_attractor_search():
 
     # real bnet
     bn = BooleanNetwork.from_file("models/bbm-bnet-inputs-true/014.bnet")
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert att == 2
     assert maa == 0
     assert min == 2
 
     # real bnet
     bn = BooleanNetwork.from_file("models/bbm-bnet-inputs-true/177.bnet")
-    n, size, depth, att, maa, min = attractor_search(bn)
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
     assert att == 2
     assert maa == 0
     assert min == 2
@@ -305,8 +319,9 @@ def test_attractor_search():
     n18, (!n7 & !n18) | (!n7 & n18)
     n19, (!n5 & !n12) | (!n5 & n12)"""
     )
-    n, size, depth, att, maa, min = attractor_search(bn)
-    assert size == 15
+    n, size, e_size, depth, att, maa, min = attractor_search(bn)
+    assert size == 21
+    assert e_size == 13
     assert min == 6
     assert att == 6
     assert maa == 0

--- a/tests/source_block_test.py
+++ b/tests/source_block_test.py
@@ -2,12 +2,19 @@ from biodivine_aeon import BooleanNetwork
 
 from biobalm import SuccessionDiagram
 
+
 def expansion(bn: BooleanNetwork):
     sd = SuccessionDiagram(bn)
     fully_expanded = sd.expand_block(find_motif_avoidant_attractors=False)
     assert fully_expanded
 
-    return bn.variable_count(), len(sd), len(list(sd.expanded_ids())), sd.depth(), len(sd.minimal_trap_spaces())
+    return (
+        bn.variable_count(),
+        len(sd),
+        len(list(sd.expanded_ids())),
+        sd.depth(),
+        len(sd.minimal_trap_spaces()),
+    )
 
 
 def test_expansion():

--- a/tests/space_utils_test.py
+++ b/tests/space_utils_test.py
@@ -143,3 +143,30 @@ def test_space_unique_key():
     )
     assert space_unique_key({"a": 1}, bn) == space_unique_key({"a": 1}, bn)
     assert space_unique_key({"a": 1}, bn) != space_unique_key({"b": 1}, bn)
+
+
+def test_perc_and_remove_constants_from_bn():
+    bn = BooleanNetwork.from_bnet(
+        """targets,factors
+    constant1_1, (constant1_1 | !constant1_1)
+    constant1_0, (constant1_0 & !constant1_0)
+    constant2_1, true
+    constant2_0, false
+    source, source
+    oscillator, !oscillator
+    source_after_perc, source_after_perc & constant1_1
+    after_perc_0, after_perc_0 & constant1_0"""
+    ).infer_valid_graph()
+
+    clean_bnet = percolate_network(bn, {}, remove_constants=True).to_bnet()
+
+    bn2 = BooleanNetwork.from_bnet(
+        """targets,factors
+    source, source
+    oscillator, !oscillator
+    source_after_perc, source_after_perc"""
+    )
+
+    clean_bnet2 = percolate_network(bn2, {}, remove_constants=True).to_bnet()
+
+    assert clean_bnet == clean_bnet2

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -7,9 +7,6 @@ import biobalm.succession_diagram
 from biobalm.succession_diagram import SuccessionDiagram
 from biobalm.types import BooleanSpace
 
-# This just ensures that the debug outputs are a part of the test output.
-biobalm.succession_diagram.DEBUG = True
-
 
 class SuccessionDiagramTest(unittest.TestCase):
     def test_succession_diagram_structure(self):
@@ -160,7 +157,6 @@ def test_expansion_size_limit_dfs():
 
 def test_expansion_comparisons(network_file: str):
     # Compare the succession diagrams for various expansion methods.
-    biobalm.succession_diagram.DEBUG = True
     NODE_LIMIT = 100
     DEPTH_LIMIT = 10
 


### PR DESCRIPTION
This PR builds on #118 and introduces a new "scc-like" expansion algorithm that is more efficient and (hopefully) easier to follow and prove.

Main advantages of the new approach:
 1. In SCC expansion, when we "recreate" the SCC-diagram inside the "main" diagram, we are only creating expanded nodes. I.e. it no longer holds that if a node is expanded, its successor nodes are the same as in the full succession diagram. The new approach satisfies that each node is either fully expanded, or not expanded at all. (We could probably fix this in SCC expansion if we wanted to, but here it holds by design)
 2. In SCC expansion, we are not guaranteed to uncover the smallest subspace for every MAA attractor. Technically, we don't miss any MAAs, but that's only because of (1) (the more specific unexpanded nodes are missing completely from the SD, hence the MAA is found in the less-specific subspace instead). This expansion should always find the minimal superspace for each MAA, if desired. However, this might have been a property in the SCC expansion before and I just broke it in #118?
 3. In SCC expansion, we use another algorithm to expand the inner SCC-diagrams. We can recursively use the SCC expansion here to obtain smaller diagrams, but overall this is a bit "over-engineered". In the new approach, the expansion condition is local to each node, thus no need for inner diagrams or recursion.
 4. SCC expansion can become inefficient if the source SCCs don't have any stable motifs (e.g. all are oscillating inputs). Here, we instead use "source blocks" which have the same effect but can incorporate source SCC w/o stable motifs.

Performance TL;DR:
 * Technically, due to (1), this creates more SD nodes than the SCC expansion. However, the number of *expanded* nodes (i.e. those that actually matter) is in general smaller or equivalent. Specifically: 
     * BBM-002, SCC expansion: 243; Block expansion: 174 expanded (599 all);
     * BBM-079, SCC expansion: 915; Block expansion: 115 expanded (655 all);
     * BBM-034, SCC expansion: 2586; Block expansion: 386 expanded (838 all);
     * BBM-143, SCC expansion: 529; Block expansion: 529 expanded (793 all);
 * Overall, the method seems to be a slightly faster, but this might just be the reduced overhead due to not needing the recursive succession diagrams.
 
How does it work:

 1. It uses the same BFS-style exploration as SCC-expansion.
 2. When a node is considered, it is first fully expanded (obtaining all successors).
 3. For each successor, we obtain its stable motif and compute its "block", i.e. a backward-closed superset of variables that are fixed by the stable motif. In most typical cases, a "block" is a source SCC, but it can also contain multiple SCCs if there is a stable motif outside of a source SCC.
 4. Successors nodes are grouped based on the blocks in which their stable motif appears. We also disregard any inclusion non-minimal blocks, as these are not the "source" blocks (i.e. the stable motifs in those depend on other, smaller blocks). 
 5. If we don't care about MAAs, we simply pick the block with the least amount of motifs and continue expanding all nodes corresponding to this block. We know that the remaining blocks are "independent" (similar to how source SCCs are independent).
 6. If we care about MAAs, we pick a block for which we can prove the corresponding sub-network has no MAAs in its root node. This block is safe to expand and won't have any MAAs, because every state in the "full" network can replicate a path in the sub-network that eventually leaves the sub-network's root node. This essentially "defers" the expansion of MAA trap spaces until the last possible moment. If no such block exists (all source blocks have MAAs), we expand the node completely, since the MAA(s) can be anywhere. 

Other minor notes:
 * The simulation limit now depends on the size of the network. Previously this was constant, hence some small networks were taking a relatively long time to finish because they were "stuck" in simulation even though the problem could have been quickly solved by reachability. Now we will only use these extreme limits for very large networks where reachability is unlikely to help.