### PR TITLE
Expansion limits

### DIFF
--- a/biobalm/_sd_algorithms/expand_attractor_seeds.py
+++ b/biobalm/_sd_algorithms/expand_attractor_seeds.py
@@ -22,7 +22,7 @@ def expand_attractor_seeds(sd: SuccessionDiagram, size_limit: int | None = None)
     # because for every attractor in a minimal trap space, we already have the
     # closest trap space, now we just need to do the same for (potential)
     # motif-avoidant attractors.
-    sd.expand_minimal_spaces(size_limit)
+    sd.expand_minimal_spaces(size_limit=size_limit)
 
     if sd.config["debug"]:
         print(

--- a/biobalm/_sd_algorithms/expand_minimal_spaces.py
+++ b/biobalm/_sd_algorithms/expand_minimal_spaces.py
@@ -9,18 +9,24 @@ from biobalm.space_utils import is_subspace
 from biobalm.trappist_core import trappist
 
 
-def expand_minimal_spaces(sd: SuccessionDiagram, size_limit: int | None = None) -> bool:
+def expand_minimal_spaces(
+    sd: SuccessionDiagram, node_id: int | None, size_limit: int | None = None
+) -> bool:
     """
     See `SuccessionDiagram.expand_minimal_spaces` for documentation.
     """
 
-    minimal_traps = trappist(sd.petri_net, problem="min")
+    if node_id is None:
+        node_id = sd.root()
 
-    root = sd.root()
+    pn = sd.node_percolated_petri_net(node_id, compute=True)
+    node_space = sd.node_data(node_id)["space"]
 
-    seen = set([root])
+    minimal_traps = trappist(network=pn, problem="min", ensure_subspace=node_space)
 
-    stack: list[tuple[int, list[int] | None]] = [(root, None)]
+    seen = set([node_id])
+
+    stack: list[tuple[int, list[int] | None]] = [(node_id, None)]
 
     while len(stack) > 0:
         (node, successors) = stack.pop()

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1257,7 +1257,9 @@ class SuccessionDiagram:
         """
         return expand_dfs(self, node_id, dfs_stack_limit, size_limit)
 
-    def expand_minimal_spaces(self, size_limit: int | None = None) -> bool:
+    def expand_minimal_spaces(
+        self, node_id: int | None = None, size_limit: int | None = None
+    ) -> bool:
         """
         Expands the succession diagram in a way that guarantees every minimal
         trap space to be reachable from the root node, but otherwise (greedily)
@@ -1272,8 +1274,15 @@ class SuccessionDiagram:
         vary if some nodes are already expanded initially. In such case, the
         procedure still tries to avoid expanding unnecessary nodes, which means
         existing expanded nodes can be prioritised over the "canonical" ones.
+
+        Optionally, you can start the expansion from a specific node that is not
+        the root using `node_id`, or restrict the size of the succession diagram
+        with `size_limit`.
+
+        Returns `True` if the expansion procedure terminated without exceeding
+        the size limit.
         """
-        return expand_minimal_spaces(self, size_limit)
+        return expand_minimal_spaces(self, node_id, size_limit)
 
     def expand_attractor_seeds(self, size_limit: int | None = None) -> bool:
         """

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1193,7 +1193,12 @@ class SuccessionDiagram:
         """
         return expand_source_SCCs(self, check_maa=find_motif_avoidant_attractors)
 
-    def expand_block(self, find_motif_avoidant_attractors: bool = True) -> bool:
+    def expand_block(
+        self,
+        find_motif_avoidant_attractors: bool = True,
+        size_limit: int | None = None,
+        optimize_source_nodes: bool = True,
+    ) -> bool:
         """
         Expand the succession diagram using the source block method.
 
@@ -1201,9 +1206,22 @@ class SuccessionDiagram:
         If set to `False`, the expansion only expands one "source block" for each node,
         without checking any attractor properties. If set to `True`, the expansion might
         expand some nodes fully to uncover nodes that precisely cover motif
-        avoidant attractors.
+        avoidant attractors. As a byproduct, if set to `True` and no motif avoidant attractors
+        are detected for some node, this is result is saved and the attractors don't
+        need to be recomputed later.
+
+        By default, the method also detects any source nodes and directly expands these
+        into trap spaces where all source nodes are fixed. This has no correctness impact on
+        attractor search and always produces a smaller succession diagram, but if you need to
+        obtain a succession diagram where this does not happen (e.g. for testing), you can turn
+        this off using `optimize_source_nodes`.
         """
-        return expand_source_blocks(self, find_motif_avoidant_attractors)
+        return expand_source_blocks(
+            self,
+            find_motif_avoidant_attractors,
+            size_limit=size_limit,
+            optimize_source_nodes=optimize_source_nodes,
+        )
 
     def expand_bfs(
         self,

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -175,6 +175,10 @@ def test_expansion_comparisons(network_file: str):
     sd_min = SuccessionDiagram(bn)
     assert sd_min.expand_minimal_spaces(size_limit=NODE_LIMIT)
 
+    assert sd_bfs.is_isomorphic(sd_dfs)
+    assert sd_min.is_subgraph(sd_bfs)
+    assert sd_min.is_subgraph(sd_dfs)
+
     # Expand the first node fully, and then expand the rest
     # until minimal trap spaces are found.
     sd_min_larger = SuccessionDiagram(bn)
@@ -183,12 +187,29 @@ def test_expansion_comparisons(network_file: str):
         if not sd_min_larger.node_data(node_id)["expanded"]:
             assert sd_min_larger.expand_minimal_spaces(node_id=node_id)
 
-    assert sd_bfs.is_isomorphic(sd_dfs)
-    assert sd_min.is_subgraph(sd_bfs)
-    assert sd_min.is_subgraph(sd_dfs)
     assert sd_min_larger.is_subgraph(sd_bfs)
     assert sd_min_larger.is_subgraph(sd_dfs)
     assert len(sd_min_larger) >= len(sd_min)
+
+    # Normal block expansion with size limit.
+    sd_block = SuccessionDiagram(bn)
+    assert sd_block.expand_block(
+        find_motif_avoidant_attractors=True,
+        size_limit=NODE_LIMIT,
+        optimize_source_nodes=False,  # Needed for compatibility.
+    )
+
+    assert sd_block.is_subgraph(sd_bfs)
+    assert sd_block.is_subgraph(sd_dfs)
+
+    block_trap = [
+        sd_block.node_data(i)["space"] for i in sd_block.minimal_trap_spaces()
+    ]
+    min_trap = [sd_min.node_data(i)["space"] for i in sd_min.minimal_trap_spaces()]
+    for t in block_trap:
+        assert t in min_trap
+    for t in min_trap:
+        assert t in block_trap
 
     sd_attr = SuccessionDiagram(bn)
     assert sd_attr.expand_attractor_seeds(size_limit=NODE_LIMIT)

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -171,12 +171,24 @@ def test_expansion_comparisons(network_file: str):
         # succession_diagram is too large for this test.
         return
 
+    # Normal minimal trap space expansion.
     sd_min = SuccessionDiagram(bn)
     assert sd_min.expand_minimal_spaces(size_limit=NODE_LIMIT)
+
+    # Expand the first node fully, and then expand the rest
+    # until minimal trap spaces are found.
+    sd_min_larger = SuccessionDiagram(bn)
+    sd_min_larger._expand_one_node(sd_min_larger.root())  # type: ignore
+    for node_id in sd_min_larger.node_ids():
+        if not sd_min_larger.node_data(node_id)["expanded"]:
+            assert sd_min_larger.expand_minimal_spaces(node_id=node_id)
 
     assert sd_bfs.is_isomorphic(sd_dfs)
     assert sd_min.is_subgraph(sd_bfs)
     assert sd_min.is_subgraph(sd_dfs)
+    assert sd_min_larger.is_subgraph(sd_bfs)
+    assert sd_min_larger.is_subgraph(sd_dfs)
+    assert len(sd_min_larger) >= len(sd_min)
 
     sd_attr = SuccessionDiagram(bn)
     assert sd_attr.expand_attractor_seeds(size_limit=NODE_LIMIT)


### PR DESCRIPTION
This PR adds a few extra options to the expansion methods, but otherwise should not impact performance or correctness.

 - `expand_minimal_spaces` now has an optional starting node.
 - `expand_block` now has a size limit.
 - `expand_block` now has an `optimize_source_nodes` flag: this is mainly to ensure compatibility in tests. Normal expansion performs source node elimination before percolation, but block expansion does it after percolation, so it might run into source nodes that the full expansion does not see. In such case the two diagrams can be incomparable, even though both are technically correct.