### PR TITLE
Add a fallback to the fully symbolic attractor detection if the NFVS search fails

### DIFF
--- a/biobalm/_sd_algorithms/expand_source_blocks.py
+++ b/biobalm/_sd_algorithms/expand_source_blocks.py
@@ -201,10 +201,16 @@ def expand_source_blocks(
                     # MAAs in the problematic nodes while using the nice properties of the expansion to
                     # still disprove MAAs in the remaining nodes. If we used `seeds`, the expansion could
                     # just get stuck on this node and the "partial" results wouldn't be usable.
-                    block_sd_candidates = block_sd.node_attractor_candidates(
-                        block_sd.root(), compute=True
-                    )
-                    if len(block_sd_candidates) == 0:
+                    is_clean = False
+                    try:
+                        block_sd_candidates = block_sd.node_attractor_candidates(
+                            block_sd.root(), compute=True
+                        )
+                        is_clean = len(block_sd_candidates) == 0
+                    except RuntimeError:
+                        is_clean = False
+
+                    if is_clean:
                         if sd.config["debug"]:
                             print(
                                 f" > [{node}] Found clean block with no MAAs ({len(block_nodes)}): {block_nodes}"
@@ -217,7 +223,7 @@ def expand_source_blocks(
                     else:
                         if sd.config["debug"]:
                             print(
-                                f"[{node}] > Found {len(block_sd_candidates)} MAA cnadidates in a block. Delaying expansion."
+                                f"[{node}] > Found MAA candidates in a block (or failed candidate search). Delaying expansion."
                             )
                 if not clean_block_found:
                     # If all blocks have MAAs, we expand all successors.


### PR DESCRIPTION
This is very straightforward: if the NFVS method produces more than `attractor_candidates_limit` candidate states, fall back to basic symbolic search using AEON.

This is not very common (hence I added an optional flag to enable this behavior which is *off* by default), but it does help with a few variants of model `002` and `079` where we would otherwise just get stuck on enumerating the attractor candidate states. However, it may be necessary to manually decrease the `attractor_candidates_limit` to get the full performance benefit (enumerating 100_000 candidates, which is the default, still takes a lot of time).

