### PR TITLE
Skip nodes

### DIFF
--- a/biobalm/_sd_algorithms/expand_minimal_spaces.py
+++ b/biobalm/_sd_algorithms/expand_minimal_spaces.py
@@ -28,6 +28,7 @@ def expand_minimal_spaces(
     node_space = sd.node_data(node_id)["space"]
 
     all_minimal_traps = trappist(network=pn, problem="min", ensure_subspace=node_space)
+    all_minimal_traps = [(node_space | x) for x in all_minimal_traps]
     # We don't need to duplicate the actual trap spaces, just the list.
     minimal_traps = copy.copy(all_minimal_traps)
 
@@ -53,6 +54,7 @@ def expand_minimal_spaces(
                 m_id = sd._ensure_node(node_id, m_trap)  # type: ignore
                 m_data = sd.node_data(m_id)
                 m_data["expanded"] = True
+                assert sd.node_is_minimal(m_id)
                 skip_edges += 1
 
         node["expanded"] = True

--- a/biobalm/_sd_algorithms/expand_minimal_spaces.py
+++ b/biobalm/_sd_algorithms/expand_minimal_spaces.py
@@ -5,12 +5,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from biobalm.succession_diagram import SuccessionDiagram
 
+import copy
 from biobalm.space_utils import is_subspace
 from biobalm.trappist_core import trappist
+from biobalm.types import BooleanSpace
 
 
 def expand_minimal_spaces(
-    sd: SuccessionDiagram, node_id: int | None, size_limit: int | None = None
+    sd: SuccessionDiagram,
+    node_id: int | None,
+    size_limit: int | None = None,
+    skip_remaining: bool = False,
 ) -> bool:
     """
     See `SuccessionDiagram.expand_minimal_spaces` for documentation.
@@ -22,7 +27,9 @@ def expand_minimal_spaces(
     pn = sd.node_percolated_petri_net(node_id, compute=True)
     node_space = sd.node_data(node_id)["space"]
 
-    minimal_traps = trappist(network=pn, problem="min", ensure_subspace=node_space)
+    all_minimal_traps = trappist(network=pn, problem="min", ensure_subspace=node_space)
+    # We don't need to duplicate the actual trap spaces, just the list.
+    minimal_traps = copy.copy(all_minimal_traps)
 
     if sd.config["debug"]:
         print(
@@ -32,6 +39,27 @@ def expand_minimal_spaces(
     seen = set([node_id])
 
     stack: list[tuple[int, list[int] | None]] = [(node_id, None)]
+
+    def make_skip_node(
+        sd: SuccessionDiagram, node_id: int, all_minimal_traps: list[BooleanSpace]
+    ):
+        node = sd.node_data(node_id)
+        if node["expanded"]:
+            return
+
+        skip_edges = 0
+        for m_trap in all_minimal_traps:
+            if is_subspace(m_trap, sd.node_data(node_id)["space"]):
+                m_id = sd._ensure_node(node_id, m_trap)  # type: ignore
+                m_data = sd.node_data(m_id)
+                m_data["expanded"] = True
+                skip_edges += 1
+
+        node["expanded"] = True
+        node["skipped"] = True
+
+        if sd.config["debug"]:
+            print(f"[{node_id}] Node skipped with {skip_edges} edges.")
 
     while len(stack) > 0:
         (node, successors) = stack.pop()
@@ -51,10 +79,13 @@ def expand_minimal_spaces(
         # do not cover any new minimal trap space.
         while len(successors) > 0:
             if successors[-1] in seen:
+                # Everything in seen is expanded, so no need to skip it.
                 successors.pop()
                 continue
             if len([s for s in minimal_traps if is_subspace(s, node_space)]) == 0:
-                successors.pop()
+                skipped = successors.pop()
+                if skip_remaining:
+                    make_skip_node(sd, skipped, all_minimal_traps)
                 continue
             break
 
@@ -64,6 +95,8 @@ def expand_minimal_spaces(
         if len(successors) == 0:
             if sd.node_is_minimal(node):
                 minimal_traps.remove(sd.node_data(node)["space"])
+                if sd.config["debug"]:
+                    print(f"Remaining minimal traps: {len(minimal_traps)}.")
             continue
 
         # At this point, we know that `s` is not visited and it contains
@@ -76,6 +109,9 @@ def expand_minimal_spaces(
         stack.append((node, successors))
         # Push the successor onto the stack.
         stack.append((s, None))
+
+        if sd.config["debug"]:
+            print(f"[{s}] Expanding...")
 
     assert len(minimal_traps) == 0
     return True

--- a/biobalm/_sd_algorithms/expand_source_blocks.py
+++ b/biobalm/_sd_algorithms/expand_source_blocks.py
@@ -15,6 +15,7 @@ def expand_source_blocks(
     check_maa: bool = True,
     size_limit: int | None = None,
     optimize_source_nodes: bool = True,
+    check_maa_exact: bool = False,
 ) -> bool:
     """
     Base correctness assumptions:
@@ -203,9 +204,14 @@ def expand_source_blocks(
                     # just get stuck on this node and the "partial" results wouldn't be usable.
                     is_clean = False
                     try:
-                        block_sd_candidates = block_sd.node_attractor_candidates(
-                            block_sd.root(), compute=True
-                        )
+                        if check_maa_exact:
+                            block_sd_candidates = block_sd.node_attractor_seeds(
+                                block_sd.root(), compute=True, symbolic_fallback=True
+                            )
+                        else:
+                            block_sd_candidates = block_sd.node_attractor_candidates(
+                                block_sd.root(), compute=True
+                            )
                         is_clean = len(block_sd_candidates) == 0
                     except RuntimeError:
                         is_clean = False

--- a/biobalm/_sd_attractors/attractor_candidates.py
+++ b/biobalm/_sd_attractors/attractor_candidates.py
@@ -124,7 +124,7 @@ def compute_attractor_candidates(
         ]
 
     if node_data["skipped"]:
-        # For skip nodes, it does not holds that the successors are the maximal subspaces.
+        # For skip nodes, it does not hold that the successors are the maximal subspaces.
         # This means that a skip node can intersect with some other SD node and that intersection
         # is not a subset of one of its children. In such case, we can use this intersection
         # to further simplify the attractor detection process.

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1637,6 +1637,6 @@ class SuccessionDiagram:
         # approach these... but this is probably good enough for now.
         if not self.dag.has_edge(parent_id, child_id):  # type: ignore
             self.dag.add_edge(parent_id, child_id, motif=stable_motif)  # type: ignore
-            if self.config["debug"]:
-                print(f"[{parent_id}] Created edge into node {child_id}.")
+            #if self.config["debug"]:
+            #    print(f"[{parent_id}] Created edge into node {child_id}.")
         self._update_node_depth(child_id, parent_id)

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1637,6 +1637,4 @@ class SuccessionDiagram:
         # approach these... but this is probably good enough for now.
         if not self.dag.has_edge(parent_id, child_id):  # type: ignore
             self.dag.add_edge(parent_id, child_id, motif=stable_motif)  # type: ignore
-            #if self.config["debug"]:
-            #    print(f"[{parent_id}] Created edge into node {child_id}.")
         self._update_node_depth(child_id, parent_id)

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -1253,7 +1253,7 @@ class SuccessionDiagram:
         all attractors, meaning it can get "stuck". However, assuming you want to run full attractor
         detection anyway, this might save you some time, as you won't need to re-run  the failed
         candidate detection. (This is only relevant for models where the attractors are very
-        complex and the candidate state detection can fail with default settings)
+        complex and the candidate state detection can fail with default settings).
         """
         return expand_source_blocks(
             self,

--- a/biobalm/symbolic_utils.py
+++ b/biobalm/symbolic_utils.py
@@ -73,14 +73,7 @@ def state_list_to_bdd(
         if isinstance(bdd_context, BddVariableSet)
         else bdd_context.bdd_variable_set()
     )
-    # There seems to be some bug in the "mk_dnf" function that makes some
-    # input instances shockingly slow. I am switching back to the "normal"
-    # enumeration method for now.
-    result = bdd.mk_false()
-    for clause in states:
-        result = result.l_or(bdd.mk_conjunctive_clause(clause))
-    return result
-    # return bdd.mk_dnf(states)
+    return bdd.mk_dnf(states)
 
 
 def function_eval(f: Bdd, state: BooleanSpace) -> Literal[0, 1] | None:

--- a/biobalm/symbolic_utils.py
+++ b/biobalm/symbolic_utils.py
@@ -73,7 +73,14 @@ def state_list_to_bdd(
         if isinstance(bdd_context, BddVariableSet)
         else bdd_context.bdd_variable_set()
     )
-    return bdd.mk_dnf(states)
+    # There seems to be some bug in the "mk_dnf" function that makes some
+    # input instances shockingly slow. I am switching back to the "normal"
+    # enumeration method for now.
+    result = bdd.mk_false()
+    for clause in states:
+        result = result.l_or(bdd.mk_conjunctive_clause(clause))
+    return result
+    # return bdd.mk_dnf(states)
 
 
 def function_eval(f: Bdd, state: BooleanSpace) -> Literal[0, 1] | None:

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -167,6 +167,26 @@ class NodeData(TypedDict):
     expanding its predecessors).
     """
 
+    skipped: bool | None
+    """
+    If `True`, indicates that the successors of this node are not the normal
+    maximal trap spaces, but rather some smaller trap spaces deeper in the
+    succession diagram. The only requirement is that all minimal trap spaces
+    that are reachable from this "skip node" are still reachable through
+    this modified set of successors (in the most basic form, the successors
+    can be the minimal trap spaces themselves).
+
+    For skip nodes, attractor detection still works, but can over-count
+    motif-avoidant attractors assuming the attractor intersects multiple
+    skip nodes. In other words, each attractor is still found, but it is
+    not necessarily true that its smallest trap space is discovered.
+    Nevertheless, if the network has no motif-avoidant attractors, the
+    result is always the same regardless of how many skip nodes are used.
+
+    A skip node is considered "expanded", since its outgoing edges are
+    computed.
+    """
+
 
 class SuccessionDiagramConfiguration(TypedDict):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    'biodivine_aeon >=1.0.0',
+    'biodivine_aeon >=1.0.1',
     'clingo >=5.6.2',
     'networkx >=2.8.8',    
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    'biodivine_aeon ==1.0.0a10',
+    'biodivine_aeon >=1.0.0',
     'clingo >=5.6.2',
     'networkx >=2.8.8',    
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biodivine_aeon==1.0.0a10
+biodivine_aeon>=1.0.0
 clingo==5.6.2
 networkx==2.8.8
 pypint[pint]==1.6.2

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from biodivine_aeon import AsynchronousGraph, Attractors, BooleanNetwork
 
+import copy
 import biobalm
 import biobalm.succession_diagram
 from biobalm.succession_diagram import SuccessionDiagram
@@ -254,6 +255,13 @@ def test_attractor_detection(network_file: str):
     if not fully_expanded:
         return
 
+    # Partial succession diagrams
+    sd_min_partial = SuccessionDiagram(bn)
+    sd_min_partial.expand_minimal_spaces(size_limit=10, skip_remaining=True)
+    sd_block_partial = SuccessionDiagram(bn)
+    sd_block_partial.expand_block(size_limit=10)
+    sd_block_partial.skip_remaining()
+
     # Compute attractors in diagram nodes.
     # TODO: There will probably be a method that does this in one "go".
     nfvs_attractors: list[BooleanSpace] = []
@@ -265,12 +273,25 @@ def test_attractor_detection(network_file: str):
         if len(attr) > 0:
             nfvs_attractors += attr
 
+    min_partial_attractors: list[BooleanSpace] = []
+    for i in sd_min_partial.node_ids():
+        attr = sd_min_partial.node_attractor_seeds(i, compute=True)
+        if len(attr) > 0:
+            min_partial_attractors += attr
+
+    block_partial_attractors: list[BooleanSpace] = []
+    for i in sd_block_partial.node_ids():
+        attr = sd_block_partial.node_attractor_seeds(i, compute=True)
+        if len(attr) > 0:
+            block_partial_attractors += attr
+
     # Compute symbolic attractors using AEON.
-    symbolic_attractors = Attractors.attractors(stg, stg.mk_unit_colored_vertices())
+    symbolic_attractors_all = Attractors.attractors(stg, stg.mk_unit_colored_vertices())
 
     # Check that every "seed" returned by SuccessionDiagram appears in
     # some symbolic attractor, and that every symbolic attractor contains
     # at most one such "seed" state.
+    symbolic_attractors = copy.copy(symbolic_attractors_all)
     for seed in nfvs_attractors:
         symbolic_seed = stg.mk_subspace(seed)
         found = None
@@ -284,9 +305,35 @@ def test_attractor_detection(network_file: str):
 
         symbolic_attractors.pop(found)
 
-    print("Attractors:", len(nfvs_attractors))
-
     # All symbolic attractors must be covered by some seed at this point.
+    assert len(symbolic_attractors) == 0
+
+    # Copy of the test above, but for the results from partially expanded diagrams.
+
+    symbolic_attractors = copy.copy(symbolic_attractors_all)
+    for seed in min_partial_attractors:
+        symbolic_seed = stg.mk_subspace(seed)
+        found = None
+
+        for i in range(len(symbolic_attractors)):
+            if symbolic_seed.is_subset(symbolic_attractors[i]):
+                found = i
+        assert found is not None
+
+        symbolic_attractors.pop(found)
+    assert len(symbolic_attractors) == 0
+
+    symbolic_attractors = copy.copy(symbolic_attractors_all)
+    for seed in block_partial_attractors:
+        symbolic_seed = stg.mk_subspace(seed)
+        found = None
+
+        for i in range(len(symbolic_attractors)):
+            if symbolic_seed.is_subset(symbolic_attractors[i]):
+                found = i
+        assert found is not None
+
+        symbolic_attractors.pop(found)
     assert len(symbolic_attractors) == 0
 
 

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -255,12 +255,25 @@ def test_attractor_detection(network_file: str):
     if not fully_expanded:
         return
 
-    # Partial succession diagrams
+    # Build partial succession diagrams.
     sd_min_partial = SuccessionDiagram(bn)
-    sd_min_partial.expand_minimal_spaces(size_limit=10, skip_remaining=True)
+    sd_min_partial.expand_minimal_spaces(size_limit=10, skip_ignored=True)
+    sd_min_partial.skip_remaining()
     sd_block_partial = SuccessionDiagram(bn)
     sd_block_partial.expand_block(size_limit=10)
     sd_block_partial.skip_remaining()
+
+    # Check that the minimal trap spaces match
+    for node in sd_min_partial.node_ids():
+        sd_id = sd.find_node(sd_min_partial.node_data(node)["space"])
+        assert sd_id is not None
+        assert sd.node_is_minimal(sd_id) == sd_min_partial.node_is_minimal(node)
+    for node in sd_block_partial.node_ids():
+        sd_id = sd.find_node(sd_block_partial.node_data(node)["space"])
+        assert sd_id is not None
+        assert sd.node_is_minimal(sd_id) == sd_block_partial.node_is_minimal(node)
+    assert len(sd.minimal_trap_spaces()) == len(sd_min_partial.minimal_trap_spaces())
+    assert len(sd.minimal_trap_spaces()) == len(sd_block_partial.minimal_trap_spaces())
 
     # Compute attractors in diagram nodes.
     # TODO: There will probably be a method that does this in one "go".


### PR DESCRIPTION
This PR introduces "skip nodes". These are nodes that are not expanded, but instead "skip" the rest of the succession diagram and lead to some of the child spaces further down in the succession diagram (by default, these are minimal trap spaces). To preserve the correctness of other methods, it is required that each skip node still has successors that cover every minimal trap space relevant for that skip node (this is mainly to ensure that we don't detect the attractors in minimal trap spaces multiple times).

This makes it possible to stop the expansion at a particular SD size and run attractor detection that uses all available information, even if the SD is incomplete.