### PR TITLE
Add option to avoid source node auto expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,10 @@ jobs:
         python -m pip install flake8 black mypy
         python -m pip install -r requirements.txt
     - name: Lint with Black
-      uses: rickstaa/action-black@v1
+      uses: psf/black@stable
       with:
-        black_args: ". --check --diff"
+        options: "--check --diff"
+        version: "25.1.0"
     - name: Check types
       run: |
         mypy biobalm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       uses: psf/black@stable
       with:
         options: "--check --diff"
-        version: "25.1.0"
+        version: "25.1.0" # If you change this, also update requirements-dev.txt
     - name: Check types
       run: |
         mypy biobalm

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -185,7 +185,7 @@ class SuccessionDiagram:
             "attractor_candidates_limit": 100_000,
             "retained_set_optimization_threshold": 1_000,
             "minimum_simulation_budget": 1_000,
-            "auto_expand_input_nodes": True,
+            "auto_expand_source_nodes": True,
         }
 
     @staticmethod
@@ -1546,7 +1546,7 @@ class SuccessionDiagram:
         # The SD created from the restricted Petri net is technically correct, but can
         # propagate some of the input values further and yields a smaller SD.
         source_nodes = []
-        if node_id == self.root() and self.config["auto_expand_input_nodes"]:
+        if node_id == self.root() and self.config["auto_expand_source_nodes"]:
             source_nodes = extract_source_variables(self.petri_net)
 
         sub_spaces: list[BooleanSpace]

--- a/biobalm/succession_diagram.py
+++ b/biobalm/succession_diagram.py
@@ -185,6 +185,7 @@ class SuccessionDiagram:
             "attractor_candidates_limit": 100_000,
             "retained_set_optimization_threshold": 1_000,
             "minimum_simulation_budget": 1_000,
+            "auto_expand_input_nodes": True,
         }
 
     @staticmethod
@@ -1545,7 +1546,7 @@ class SuccessionDiagram:
         # The SD created from the restricted Petri net is technically correct, but can
         # propagate some of the input values further and yields a smaller SD.
         source_nodes = []
-        if node_id == self.root():
+        if node_id == self.root() and self.config["auto_expand_input_nodes"]:
             source_nodes = extract_source_variables(self.petri_net)
 
         sub_spaces: list[BooleanSpace]

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -281,12 +281,12 @@ class SuccessionDiagramConfiguration(TypedDict):
     [Default: 1_000]
     """
 
-    auto_expand_input_nodes: bool
+    auto_expand_source_nodes: bool
     """
-    When `biobalm` detects that the network has input nodes, it expands them all simultaneously,
-    instead of expanding them one by one. This is useful for networks with many input nodes,
+    When `biobalm` detects that the network has source nodes, it expands them all simultaneously,
+    instead of expanding them one by one. This is useful for networks with many source nodes,
     because it produces a much smaller succession diagram without losing any "interesting" behavior.
-    However, this setting needs to be disabled if only specific input nodes are to be expanded.
+    However, this setting needs to be disabled if only specific source nodes are to be expanded.
 
     [Default: True]
     """

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -229,6 +229,8 @@ class SuccessionDiagramConfiguration(TypedDict):
     intersect negative cycles to find an NFVS subset. Typically,
     for smaller networks, the trade-off is in favor of
     computing a smaller NFVS.
+
+    [Default: 2_000]
     """
 
     pint_goal_size_limit: int
@@ -242,6 +244,8 @@ class SuccessionDiagramConfiguration(TypedDict):
     The default value was empirically tested as safe on Debian linux, but other operating
     systems may need a different limit to stay safe. Nevertheless, this should not be
     an issue on smaller/simpler networks.
+
+    [Default: 8_192]
     """
 
     attractor_candidates_limit: int
@@ -249,12 +253,16 @@ class SuccessionDiagramConfiguration(TypedDict):
     If more than `attractor_candidates_limit` states are produced during the
     attractor detection process, then the process fails with a `RuntimeError`.
     This is mainly to avoid out-of-memory errors or crashing `clingo`.
+
+    [Default: 100_000]
     """
 
     retained_set_optimization_threshold: int
     """
     If there are more than this amount of attractor candidates, the attractor
     detection process will try to optimize the retained set using ASP (if enabled).
+
+    [Default: 1_000]
     """
 
     minimum_simulation_budget: int
@@ -269,6 +277,9 @@ class SuccessionDiagramConfiguration(TypedDict):
     However, this budget only applies when simulation has not been able to make progress
     in the recent round. That is, if simulation has actively eliminated some candidates in
     the recent round, it will still continue regardless of the budget limit.
+
+    [Default: 1_000]
+    """
 
     auto_expand_input_nodes: bool
     """

--- a/biobalm/types.py
+++ b/biobalm/types.py
@@ -269,4 +269,13 @@ class SuccessionDiagramConfiguration(TypedDict):
     However, this budget only applies when simulation has not been able to make progress
     in the recent round. That is, if simulation has actively eliminated some candidates in
     the recent round, it will still continue regardless of the budget limit.
+
+    auto_expand_input_nodes: bool
+    """
+    When `biobalm` detects that the network has input nodes, it expands them all simultaneously,
+    instead of expanding them one by one. This is useful for networks with many input nodes,
+    because it produces a much smaller succession diagram without losing any "interesting" behavior.
+    However, this setting needs to be disabled if only specific input nodes are to be expanded.
+
+    [Default: True]
     """

--- a/example/attractors.py
+++ b/example/attractors.py
@@ -18,12 +18,12 @@ print(f"Simplified network: {bn}")
 # Prepare a config which will print progress.
 config = SuccessionDiagram.default_config()
 config["debug"] = True  # Print progress.
-config[
-    "max_motifs_per_node"
-] = 1_000_000  # Maximum number of outgoing edges for each node.
-config[
-    "attractor_candidates_limit"
-] = 100_000  # Maximum number of enumerated attractor candidates.
+config["max_motifs_per_node"] = (
+    1_000_000  # Maximum number of outgoing edges for each node.
+)
+config["attractor_candidates_limit"] = (
+    100_000  # Maximum number of enumerated attractor candidates.
+)
 
 sd = SuccessionDiagram(bn, config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    'biodivine_aeon >=1.0.1',
+    'biodivine_aeon >=1.2.5',
     'clingo >=5.6.2',
     'networkx >=2.8.8',    
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,8 @@ astroid==3.1.0
 autodocsumm==0.2.12
 Babel==2.14.0
 beautifulsoup4==4.12.3
-biodivine_aeon==1.0.0a8
-black==24.2.0
+biodivine_aeon==1.2.5
+black==25.1.0
 boolean.py==4.0
 CacheControl==0.14.0
 certifi==2024.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biodivine_aeon>=1.0.0
+biodivine_aeon>=1.2.5
 clingo==5.6.2
 networkx==2.8.8
 pypint[pint]==1.6.2

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -419,20 +419,20 @@ def test_attractor_extraction():
     eas = sd.expanded_attractor_seeds()
     assert eas == {1: [{"A": 0, "B": 0, "C": 1}], 2: [{"A": 1, "B": 1, "C": 1}]}
 
-def test_input_auto_expand():
+def test_source_auto_expand():
     net = """
         A, A
         B, B
         """
     cfg = biobalm.SuccessionDiagram.default_config()
-    cfg["auto_expand_input_nodes"] = False
+    cfg["auto_expand_source_nodes"] = False
     sd = biobalm.SuccessionDiagram.from_rules(net, config=cfg)
     sd.expand_dfs()
     # root, A fixed, B fixed, A+B fixed
     assert len(sd) == (1 + 2 + 2 + 4)
 
     cfg = biobalm.SuccessionDiagram.default_config()
-    cfg["auto_expand_input_nodes"] = True
+    cfg["auto_expand_source_nodes"] = True
     sd = biobalm.SuccessionDiagram.from_rules(net, config=cfg)
     sd.expand_dfs()
     # root, A+B fixed

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -418,3 +418,22 @@ def test_attractor_extraction():
     sd.build()
     eas = sd.expanded_attractor_seeds()
     assert eas == {1: [{"A": 0, "B": 0, "C": 1}], 2: [{"A": 1, "B": 1, "C": 1}]}
+
+def test_input_auto_expand():
+    net = """
+        A, A
+        B, B
+        """
+    cfg = biobalm.SuccessionDiagram.default_config()
+    cfg["auto_expand_input_nodes"] = False
+    sd = biobalm.SuccessionDiagram.from_rules(net, config=cfg)
+    sd.expand_dfs()
+    # root, A fixed, B fixed, A+B fixed
+    assert len(sd) == (1 + 2 + 2 + 4)
+
+    cfg = biobalm.SuccessionDiagram.default_config()
+    cfg["auto_expand_input_nodes"] = True
+    sd = biobalm.SuccessionDiagram.from_rules(net, config=cfg)
+    sd.expand_dfs()
+    # root, A+B fixed
+    assert len(sd) == (1 + 4)

--- a/tests/succession_diagram_test.py
+++ b/tests/succession_diagram_test.py
@@ -419,6 +419,7 @@ def test_attractor_extraction():
     eas = sd.expanded_attractor_seeds()
     assert eas == {1: [{"A": 0, "B": 0, "C": 1}], 2: [{"A": 1, "B": 1, "C": 1}]}
 
+
 def test_source_auto_expand():
     net = """
         A, A


### PR DESCRIPTION
This PR adds a configuration option `auto_expand_source_nodes` which allows us to turn off auto-expansion of source nodes in the root, which was previously the default behavior. For other non-root nodes, this was part of the expansion strategy; only for the root, we always forced it until now.

This also updates the aeon dependency, because there was a minor bug in the native percolation method which made it fail if the network had free inputs (which we did not have to care until now, because they were always fixed by default).

Other minor stuff:
 - Updated `black` to use the official github action, where we can also specify a fixed tool version: https://black.readthedocs.io/en/stable/integrations/github_actions.html